### PR TITLE
retrieve address on url request too and handle errors better

### DIFF
--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -14,19 +14,29 @@ class ForecastsController < ApplicationController
   end
 
   def create
-    forecast_retriever = ForecastRetriever.new
-    zipcode = forecast_retriever.retrieve_forecast(address: weather_forecast_params.fetch(:address))
-    redirect_to forecast_path(zipcode)
+    @forecast = retrieve_forecast(address: weather_forecast_params.fetch(:address))
+    if @forecast.nil? || @forecast.errors.any?
+      render "new", locals: { forecast: @forecast } and return
+    else
+      redirect_to forecast_path(@forecast.zipcode)
+    end
   end
 
   private
 
   def validate_forecast
     unless forecast
-      flash[:error] = "Forecast not found"
-
-      redirect_to new_forecast_path
+      forecast_retriever = ForecastRetriever.new
+      @forecast = forecast_retriever.retrieve_forecast(address: forecast_zipcode_param)
+      if @forecast.nil? || @forecast.errors.any?
+        render "new", locals: { forecast: @forecast } and return
+      end
     end
+  end
+
+  def retrieve_forecast(address:)
+    forecast_retriever = ForecastRetriever.new
+    forecast_retriever.retrieve_forecast(address: address)
   end
 
   def mark_as_cached

--- a/app/views/forecasts/new.html.erb
+++ b/app/views/forecasts/new.html.erb
@@ -4,6 +4,15 @@
   <div>
     Enter an address: <%= f.text_field :address, style: "width: 300px" %>
   </div>
+
+  <% if forecast.errors.any? %>
+    <div style="color:red; margin-top: 10px">
+      <% forecast.errors.messages.each do |field, errors| %>
+        <span>Error:</span> <%= "#{field} #{errors.first}" %>
+      <% end %>
+    </div>
+  <% end %>
+
   <div style="margin-top: 15px">
     <%= f.submit %>
   </div>


### PR DESCRIPTION
Can now just enter http://localhost:3000/forecasts/[zipcode] and the app will automatically retrieve the forecast (instead of always having to go through the new form). Though this method only works for zipcodes - have to go through the form to parse full addresses still